### PR TITLE
Feat: Solving error from CLI Build with shebang and bump to the version 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "scaffold-api",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Scaffold CLI",
   "main": "build/index.js",
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "test": "node --no-warnings --loader ts-node/esm src/index.ts"
+    "start": "node build/index.js",
+    "dev": "tsx src/index.ts",
+    "prepublishOnly": "npm run build"
   },
   "bin": {
     "scaffold-api": "build/index.js"
@@ -19,7 +21,11 @@
     "name": "Igor Moura",
     "url": "https://github.com/igordmouraa"
   },
-  "keywords": ["cli", "scaffold", "api"],
+  "keywords": [
+    "cli",
+    "scaffold",
+    "api"
+  ],
   "license": "MIT",
   "dependencies": {
     "chalk": "^5.4.1",
@@ -27,10 +33,13 @@
     "ora": "^8.2.0"
   },
   "devDependencies": {
+    "@types/chalk": "^2.2.0",
     "@types/inquirer": "^9.0.7",
     "@types/node": "^22.13.10",
+    "@types/ora": "^3.2.0",
     "cross-env": "^7.0.3",
     "ts-node": "^10.9.2",
+    "tsx": "^4.19.3",
     "typescript": "^5.8.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { mainMenu } from "./menus/mainMenu/index.js";
 import ck from "chalk";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
 
     "types": ["node"],
     "allowJs": true,
-    "checkJs": false
+    "checkJs": false,
   },
   "ts-node": {
     "esm": true,


### PR DESCRIPTION
## This PR includes the fixed index.ts with the shebang ```#!/usr/bin/env node``` and that bump to ```1.1.2```

![image](https://github.com/user-attachments/assets/a6bb05be-b87c-4784-8aa8-e336db4ccbd6)
